### PR TITLE
Logic Update

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ VIEWER.findAllFeatures = async function(data, property = "navPlace", allProperty
                     //If it does not have items, then dereference.
                     if (!item.hasOwnProperty("items")) {
                         let iiif_uri = item.id ?? item["@id"] ?? ""
-                        let iiif_resolved = await fetch(iiif_uri)
+                        let iiif_resolved = await fetch(iiif_uri, {"cache":"default"})
                             .then(resp => resp.json())
                             .catch(err => {
                                 console.error(err)
@@ -80,7 +80,7 @@ VIEWER.findAllFeatures = async function(data, property = "navPlace", allProperty
                         if (!data[key].hasOwnProperty("features")) {
                             //It is either referenced or malformed
                             let data_uri = data[key].id ?? data[key]["@id"] ?? "Yikes"
-                            let data_resolved = await fetch(data_uri)
+                            let data_resolved = await fetch(data_uri, {"cache":"default"})
                                 .then(resp => resp.json())
                                 .catch(err => {
                                     console.error(err)
@@ -191,7 +191,7 @@ VIEWER.verifyResource = function() {
 VIEWER.consumeForGeoJSON = async function(dataURL) {
     let geoJSONFeatures = []
 
-    let dataObj = await fetch(dataURL)
+    let dataObj = await fetch(dataURL, {"cache":"default"})
         .then(resp => resp.json())
         .then(man => { return man })
         .catch(err => { return null })

--- a/app.js
+++ b/app.js
@@ -99,7 +99,7 @@ VIEWER.findAllFeatures = async function(data, property = "navPlace", allProperty
                     } 
                     else if (Array.isArray(data[key])) {
                         //Check if this is one of the keys we know to recurse on
-                        if(!VIEWER.iiifRecurseKeys.includes(key)){
+                        if(VIEWER.iiifRecurseKeys.includes(key)){
                             //If the top level resource is a Manifest with items[] and structures[], ignore items.
                             if(!(t1==="Manifest" && key === "items" && data.structures)){
                                 await VIEWER.findAllFeatures(data[key], property, allPropertyInstances, false)

--- a/app.js
+++ b/app.js
@@ -11,6 +11,8 @@ VIEWER.mymap = {}
 
 VIEWER.iiifResourceTypes = ["Collection", "Manifest", "Range", "Canvas"]
 
+VIEWER.iiifIgnoreKeys = ["seeAlso", "partOf"]
+
 VIEWER.iiif_prezi_contexts = ["https://iiif.io/api/presentation/3/context.json", "http://iiif.io/api/presentation/3/context.json"]
 
 VIEWER.iiif_navplace_contexts = ["http://iiif.io/api/extension/navplace/context.json", "https://iiif.io/api/extension/navplace/context.json"]
@@ -73,33 +75,36 @@ VIEWER.findAllFeatures = async function(data, property = "navPlace", allProperty
             if (VIEWER.iiifResourceTypes.includes(t1)) {
                 //Loop the keys, looks for those properties with Array values, or navPlace
                 for await (const key of keys) {
-                    if (key === property) {
-                        //This is a navPlace object, it may be referenced
-                        if (!data[key].hasOwnProperty("features")) {
-                            //It is either referenced or malformed
-                            let data_uri = data[key].id ?? data[key]["@id"] ?? "Yikes"
-                            let data_resolved = await fetch(data_uri)
-                                .then(resp => resp.json())
-                                .catch(err => {
-                                    console.error(err)
-                                    return {}
-                                })
-                            if (data_resolved.hasOwnProperty("features")) {
-                                //Then this is the one we want
-                                data[key] = data_resolved
+                    //Make sure this isn't a property we shouldn't search for navPlaces to include.
+                    if(!VIEWER.iiifIgnoreKeys.includes(key)){
+                        if (key === property) {
+                            //This is a navPlace object, it may be referenced
+                            if (!data[key].hasOwnProperty("features")) {
+                                //It is either referenced or malformed
+                                let data_uri = data[key].id ?? data[key]["@id"] ?? "Yikes"
+                                let data_resolved = await fetch(data_uri)
+                                    .then(resp => resp.json())
+                                    .catch(err => {
+                                        console.error(err)
+                                        return {}
+                                    })
+                                if (data_resolved.hasOwnProperty("features")) {
+                                    //Then this is the one we want
+                                    data[key] = data_resolved
+                                }
                             }
-                        }
-                        //Add a property to the feature collection so that it knows what type of resource it is on.
-                        //The Features will use this later to color themselves based on type.
-                        data[key].__fromResource = t1
-                        //Essentially, this is our base case.  We have navPlace and do not need to recurse.  We just continue looping the keys.
-                        allPropertyInstances.push(data[key])
-                    } else if (Array.isArray(data[key])) {
-                        //This may be 'items' or 'structures' or something, recurse on it.
-                        //If the top level resource is a Manifest with items[] and structures[], ignore items.
-                        if(!(t1==="Manifest" && key === "items" && data.structures)){
-                            await VIEWER.findAllFeatures(data[key], property, allPropertyInstances, false)
-                        }
+                            //Add a property to the feature collection so that it knows what type of resource it is on.
+                            //The Features will use this later to color themselves based on type.
+                            data[key].__fromResource = t1
+                            //Essentially, this is our base case.  We have navPlace and do not need to recurse.  We just continue looping the keys.
+                            allPropertyInstances.push(data[key])
+                        } else if (Array.isArray(data[key])) {
+                            //This may be 'items' or 'structures' or something, recurse on it.
+                            //If the top level resource is a Manifest with items[] and structures[], ignore items.
+                            if(!(t1==="Manifest" && key === "items" && data.structures)){
+                                await VIEWER.findAllFeatures(data[key], property, allPropertyInstances, false)
+                            }
+                        }    
                     }
                 }
             }


### PR DESCRIPTION
Thanks to Mark Baggett for pointing this out.  There are certain properties of IIIF resource types that may contain embedded or referenced resource types which should not be recursed through for `navPlace` properties.  `seeAlso` and `partOf` are good examples.  There is no need to process those resources for `navPlace` properties.